### PR TITLE
Set max height of main

### DIFF
--- a/docs/src/App.vue
+++ b/docs/src/App.vue
@@ -49,5 +49,7 @@ import { $iroiro } from "./global-props";
 
 .main {
   grid-area: main;
+  max-height: 100vh;
+  overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
This keeps the header and menu sticky, scrolling only the main content.
