### PR TITLE
Fix 404 on deep link

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{"source": "/(.*)", "destination": "/index.html"}]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "rewrites": [{"source": "/(.*)", "destination": "/index.html"}]
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
When the page is refreshed or a deep link is accessed without first
visiting the homepage, a 404 is displayed. This rewrites all routes to
access `/index.html`.
